### PR TITLE
Check for window and document to stop SSR crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "name": "react-simple-hook-modal",
   "description": "A simple React modal with hook based API",

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -12,10 +12,21 @@ export interface ModalProps {
   transition?: ModalTransition;
 }
 
+function hasDOM() {
+  return !!(
+    typeof window !== 'undefined' &&
+    window.document &&
+    window.document.createElement
+  );
+}
+
 export const Modal: React.FC<ModalProps> = modal => {
-  const container = document.getElementById('react-simple-modal-container');
   const { addOrUpdate, remove, getStaggerPixels } = useModalContext();
   const { id, isOpen } = modal;
+
+  const container = hasDOM()
+    ? document.getElementById('react-simple-modal-container')
+    : null;
 
   useEffect(() => {
     isOpen ? addOrUpdate(id) : remove(id);


### PR DESCRIPTION
A recent change in v1.0.0 (#11) introduced the use of a React portal to render modals. This depends on `window.document` which is not available server-side.

Here we are now checking whether `window.document` exists before trying to use it. This means `<Modal/>` cannot be rendered on the server, but generally this isn't going to required. This fixes rendering in frameworks like Next.js