### PR TITLE
Increase modal z-index and add z-index prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ import 'react-simple-hook-modal/dist/styles.css';
 - `backdropClassName` which can contain one or more classes to append and override the default styles (e.g. Changing the backdrop colour can be done by adding the class `bg-blue-800`).
 
 `Modal` also takes optional props:
+
 - `modalClassName` which can contain one or more classes to append to the default modal div.
+- `modalZIndex` this can be used to override the default z-index value should you need one higher than 999.
 
 # Example
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ import 'react-simple-hook-modal/dist/styles.css';
 `Modal` also takes optional props:
 
 - `modalClassName` which can contain one or more classes to append to the default modal div.
-- `modalZIndex` this can be used to override the default z-index value should you need one higher than 999.
+- `modalZIndex` this can be used to override the default z-index value should you need one higher than 9999.
 
 # Example
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -11,6 +11,7 @@ export interface ModalProps {
   footer?: React.ReactNode;
   transition?: ModalTransition;
   modalClassName?: string;
+  modalZIndex?: number;
 }
 
 function hasDOM() {

--- a/src/components/ModalContainer.tsx
+++ b/src/components/ModalContainer.tsx
@@ -34,9 +34,7 @@ export const ModalContainer: React.FC<ModalProps & Props> = ({
               onClick={onBackdropClick}
             >
               <div
-                className={`rsm-bg-white rsm-rounded-md rsm-overflow-auto rsm-max-h-full rsm-w-full md:rsm-w-10/12 xl:rsm-w-1/2 rsm-opactiy-100 rsm-shadow-lg rsm-z-9999 rsm-border rsm-border-gray-200 rsm-flex rsm-flex-col ${
-                  modalClassName ?? ''
-                }`}
+                className={`rsm-bg-white rsm-rounded-md rsm-overflow-auto rsm-max-h-full rsm-w-full md:rsm-w-10/12 xl:rsm-w-1/2 rsm-opactiy-100 rsm-shadow-lg rsm-z-9999 rsm-border rsm-border-gray-200 rsm-flex rsm-flex-col ${modalClassName ?? ''}`}
                 style={{
                   minHeight: '70%',
                   transition:
@@ -47,7 +45,7 @@ export const ModalContainer: React.FC<ModalProps & Props> = ({
                   transformOrigin: 'center',
                   zIndex: modalZIndex,
                 }}
-                onClick={(e) => e.stopPropagation()}
+                onClick={e => e.stopPropagation()}
               >
                 <div className="rsm-flex-1 rsm-p-8">{children}</div>
                 {!footer ? null : (

--- a/src/components/ModalContainer.tsx
+++ b/src/components/ModalContainer.tsx
@@ -18,6 +18,7 @@ export const ModalContainer: React.FC<ModalProps & Props> = ({
   onBackdropClick,
   transformDistance,
   modalClassName,
+  modalZIndex,
 }) => {
   const modalTransitions = useModalTransition(transition, isOpen);
 
@@ -33,7 +34,7 @@ export const ModalContainer: React.FC<ModalProps & Props> = ({
               onClick={onBackdropClick}
             >
               <div
-                className={`rsm-bg-white rsm-rounded-md rsm-overflow-auto rsm-max-h-full rsm-w-full md:rsm-w-10/12 xl:rsm-w-1/2 rsm-opactiy-100 rsm-shadow-lg rsm-z-50 rsm-border rsm-border-gray-200 rsm-flex rsm-flex-col ${modalClassName ??
+                className={`rsm-bg-white rsm-rounded-md rsm-overflow-auto rsm-max-h-full rsm-w-full md:rsm-w-10/12 xl:rsm-w-1/2 rsm-opactiy-100 rsm-shadow-lg rsm-z-999 rsm-border rsm-border-gray-200 rsm-flex rsm-flex-col ${modalClassName ??
                   ''}`}
                 style={{
                   minHeight: '70%',
@@ -43,6 +44,7 @@ export const ModalContainer: React.FC<ModalProps & Props> = ({
                       : 'transform ease-in-out .2s',
                   transform: `translate(${transformDistance}px, ${transformDistance}px)`,
                   transformOrigin: 'center',
+                  zIndex: modalZIndex,
                 }}
                 onClick={e => e.stopPropagation()}
               >

--- a/src/components/ModalContainer.tsx
+++ b/src/components/ModalContainer.tsx
@@ -34,9 +34,8 @@ export const ModalContainer: React.FC<ModalProps & Props> = ({
               onClick={onBackdropClick}
             >
               <div
-                className={`rsm-bg-white rsm-rounded-md rsm-overflow-auto rsm-max-h-full rsm-w-full md:rsm-w-10/12 xl:rsm-w-1/2 rsm-opactiy-100 rsm-shadow-lg rsm-z-9999 rsm-border rsm-border-gray-200 rsm-flex rsm-flex-col ${
-                  modalClassName ?? ''
-                }`}
+                className={`rsm-bg-white rsm-rounded-md rsm-overflow-auto rsm-max-h-full rsm-w-full md:rsm-w-10/12 xl:rsm-w-1/2 rsm-opactiy-100 rsm-shadow-lg rsm-z-9999 rsm-border rsm-border-gray-200 rsm-flex rsm-flex-col ${modalClassName ??
+                  ''}`}
                 style={{
                   minHeight: '70%',
                   transition:
@@ -47,7 +46,7 @@ export const ModalContainer: React.FC<ModalProps & Props> = ({
                   transformOrigin: 'center',
                   zIndex: modalZIndex,
                 }}
-                onClick={(e) => e.stopPropagation()}
+                onClick={e => e.stopPropagation()}
               >
                 <div className="rsm-flex-1 rsm-p-8">{children}</div>
                 {!footer ? null : (

--- a/src/components/ModalContainer.tsx
+++ b/src/components/ModalContainer.tsx
@@ -34,8 +34,9 @@ export const ModalContainer: React.FC<ModalProps & Props> = ({
               onClick={onBackdropClick}
             >
               <div
-                className={`rsm-bg-white rsm-rounded-md rsm-overflow-auto rsm-max-h-full rsm-w-full md:rsm-w-10/12 xl:rsm-w-1/2 rsm-opactiy-100 rsm-shadow-lg rsm-z-999 rsm-border rsm-border-gray-200 rsm-flex rsm-flex-col ${modalClassName ??
-                  ''}`}
+                className={`rsm-bg-white rsm-rounded-md rsm-overflow-auto rsm-max-h-full rsm-w-full md:rsm-w-10/12 xl:rsm-w-1/2 rsm-opactiy-100 rsm-shadow-lg rsm-z-9999 rsm-border rsm-border-gray-200 rsm-flex rsm-flex-col ${
+                  modalClassName ?? ''
+                }`}
                 style={{
                   minHeight: '70%',
                   transition:
@@ -46,7 +47,7 @@ export const ModalContainer: React.FC<ModalProps & Props> = ({
                   transformOrigin: 'center',
                   zIndex: modalZIndex,
                 }}
-                onClick={e => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
               >
                 <div className="rsm-flex-1 rsm-p-8">{children}</div>
                 {!footer ? null : (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,8 +30,8 @@ module.exports = {
       gray: colors.gray,
     },
     zIndex: {
-      '40': 40,
-      '999': 999,
+      40: 40,
+      9999: 9999,
       auto: 'auto',
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,5 +29,10 @@ module.exports = {
       white: colors.white,
       gray: colors.gray,
     },
+    zIndex: {
+      '40': 40,
+      '999': 999,
+      auto: 'auto',
+    },
   },
 };


### PR DESCRIPTION
This change adds enables the use of `rsm-z-999` which gives the modal a `z-index: 999` value.

In the tailwind config I have also left in the option for `z-index: 40` as I noticed that this was used in 2 other places and I wasn't sure what you'd want doing here, I assumed they were naturally slightly lower because of the lower limits but playing with them didn't seem to make any difference?

I also added an additional prop so that the user can specify a z-index of their own value which then gets passed through as a style which overrides the default `rsm-z-999` value. I tested this in the example app with modals 1 and 2 and each one worked respectively.